### PR TITLE
Reload at start if necessary

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -47,6 +47,7 @@
         _preloadImage();
         if (_options.autoTrigger) {
             _nextWrap(_$next);
+            while(_observe()) {} // reload at start if content height is smaller than screen height
             _$scroll.bind('scroll.jscroll', function() {
                 return _observe();
             });
@@ -113,6 +114,7 @@
                 _debug('info', 'jScroll:', $inner.outerHeight() - iTotalHeight, 'from bottom. Loading next request...');
                 return _load();
             }
+            return false;
         }
 
         // Check if the href for the next set of content has been set


### PR DESCRIPTION
Hi Phillip,

I found your very useful plugin and started experimenting with it. However I found an issue, where no content is loaded, so I fixed it.
Here is the commit comment:

"
If the autoTrigger option is set and the content's height is smaller
than the screen height, then start loading content immediately.

This fixes a bug where you can't scroll because everything fits into the
browser window, so the "scroll" event is never triggered and new content
is never loaded.
"

I hope you're ok with this fix.

regards
Gernot
