### PR TITLE
Ensure jscroll instance is destroyed if the associated div is removed fr...

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -118,7 +118,7 @@
         // Check if the href for the next set of content has been set
         function _checkNextHref(data) {
             data = data || $e.data('jscroll');
-            if (!data.nextHref) {
+            if (!data || !data.nextHref) {
                 _debug('warn', 'jScroll: nextSelector not found - destroying');
                 $e.jscroll.destroy();
                 return false;
@@ -192,6 +192,9 @@
             // Instantiate jScroll on this element if it hasn't been already
             if (data && data.initialized) return;
             var jscroll = new jScroll($this, m);
+            $($this).on("remove", function () {
+                $.fn.jscroll.destroy();
+            })
         });
     };
 })(jQuery);


### PR DESCRIPTION
...om the DOM.

If this is not done, and the div is updated/replaced in any way other than a
full browser page reload then the jscroll instance will be invalidated
and will prevent a new one being created. From an end-user perspective
JScroll would simply appear to have stopped working and wouldn't
resume working until the page was forcibly reloaded.

This made JScroll incompatible with various AJAX based methods/jQuery
plugins that would update the page content without reloading the entire page.
