### PR TITLE
Added refresh option to reinitialize the plugin on each update when used to paginate search results dynamically updated with AJAX.

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -25,7 +25,8 @@
             nextSelector: 'a:last',
             contentSelector: '',
             pagingSelector: '',
-            callback: false
+            callback: false,
+            refresh: false
         }
     };
 
@@ -44,10 +45,16 @@
             _nextHref = $.trim(_$next.attr('href') + ' ' + _options.contentSelector);
 
         // Initialization
-        $e.data('jscroll', $.extend({}, _data, {initialized: true, waiting: false, nextHref: _nextHref}));
-        _wrapInnerContent();
-        _preloadImage();
-        _setBindings();
+        if (_nextHref != 'undefined') {
+            $e.data('jscroll', $.extend({}, _data, {initialized: true, waiting: false, nextHref: _nextHref, refresh: _options.refresh}));
+            _wrapInnerContent();
+            _preloadImage();
+            _setBindings();
+        } else {
+            _debug('warn', 'jScroll: nextSelector not found - destroying');
+            _destroy();
+            return false;
+        }
 
         // Private methods
 
@@ -202,7 +209,7 @@
             var $this = $(this),
                 data = $this.data('jscroll');
             // Instantiate jScroll on this element if it hasn't been already
-            if (data && data.initialized) return;
+            if (data && data.initialized && data.refresh === false) return;
             var jscroll = new jScroll($this, m);
         });
     };


### PR DESCRIPTION
When paginating search results returned from an AJAX call...

```
$('#search').keyup(function() {
    var search = $(this).val();
    $.get('/search', {search : search}, function(results) {
        $('.scroll-table').html(results);
        $('.scroll-table').jscroll();
    });
});
```

After getting the new set of search results, when we scroll to the bottom, jScroll appends content of the next page of the previous (old) query.

So if my last _nextHref was "/search?query=A&page=3" and I enter B in the search field, instead of loading "/search?query=B&page=2" from the new href, it would load "/search?query=A&page=3" from the old href.

Refresh option added to reinitialize the plugin on each load, to prevent it from loading the old href.

Usage: 

```
$('.scroll').jscroll({
    refresh: true
});
```
