### PR TITLE
Don't show Loading message if next selector is not found during initialization.

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -43,7 +43,6 @@
             _$scroll = _isWindow ? _$window : $e,
             _nextHref = _$next.length > 0 ? $.trim(_$next.attr('href') + ' ' + _options.contentSelector) : false;
 
-
         // Initialization
         $e.data('jscroll', $.extend({}, _data, {initialized: true, waiting: false, nextHref: _nextHref}));
         _wrapInnerContent();


### PR DESCRIPTION
Currently, jscroll will still display the "Loading..." message if the "next" selector is not found when the plugin is initialized. This patch adds checks to ensure the next selector exists before trying to get its href attribute.
