### PR TITLE
Update jquery.jscroll.js

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -29,12 +29,26 @@
             nextSelector: 'a:last',
             contentSelector: '',
             pagingSelector: '',
-            callback: false
+            callback: false,
+			beforeSend:false,
+			afterContentLoad:false,
+			reTriggerUntil:0
+			
         }
     };
 
     // Constructor
     var jScroll = function($e, options) {
+
+	this.getdata=function(){
+	return $e.data('jscroll');
+	}
+	
+	this.getOptions=function(){
+	return _options;
+	}
+	
+
 
         // Private vars and methods
         var _data = $e.data('jscroll'),
@@ -121,6 +135,9 @@
                 if (!$next.length) {
                     return;
                 }
+				
+			
+					
                 if (_options.autoTrigger && (_options.autoTriggerUntil === false || _options.autoTriggerUntil > 0)) {
                     _nextWrap($next);
                     if (_$body.height() <= _$window.height()) {
@@ -134,11 +151,14 @@
                     }
                 } else {
                     _$scroll.unbind('.jscroll');
-                    $next.bind('click.jscroll', function() {
+                    $next.one('click.jscroll', function() {
                         _nextWrap($next);
                         _load();
+						
+						_options.autoTriggerUntil=_options.reTriggerUntil;
                         return false;
                     });
+					
                 }
             },
 
@@ -151,23 +171,32 @@
                 $inner.append('<div class="jscroll-added" />')
                     .children('.jscroll-added').last()
                     .html('<div class="jscroll-loading">' + _options.loadingHtml + '</div>');
-
-                return $e.animate({scrollTop: $inner.outerHeight()}, 0, function() {
-                    $inner.find('div.jscroll-added').last().load(data.nextHref, function(r, status) {
+ 			 
+			  _options.beforeSend(data);
+				
+				$.get(data.nextHref, function(r, status) {
                         if (status === 'error') {
                             return _destroy();
                         }
-                        var $next = $(this).find(_options.nextSelector).first();
+						
+						r=_options.afterContentLoad(r);
+						var div=$inner.find('div.jscroll-added').last();
+						div.html(r);
+                        var $next = $(div).find(_options.nextSelector).first();
                         data.waiting = false;
                         data.nextHref = $next.attr('href') ? $.trim($next.attr('href') + ' ' + _options.contentSelector) : false;
                         $('.jscroll-next-parent', $e).remove(); // Remove the previous next link now that we have a new one
                         _checkNextHref();
                         if (_options.callback) {
+							
                             _options.callback.call(this);
                         }
                         _debug('dir', data);
+						
+						
                     });
-                });
+               
+			 
             },
 
             // Safe console debug - http://klauzinski.com/javascript/safe-firebug-console-in-javascript
@@ -197,7 +226,9 @@
 
         // Expose API methods via the jQuery.jscroll namespace, e.g. $('sel').jscroll.method()
         $.extend($e.jscroll, {
-            destroy: _destroy
+            destroy: _destroy,
+			getdata:this.getdata,
+			getOptions:this.getOptions
         });
         return $e;
     };


### PR DESCRIPTION
Added 2 New callback function 'beforeSend' and 'afterContentLoad' and new option reTriggerUntil option
 added two public function 'getdata' and 'getOptions' , and
load request is changed to ajax get method for better content manupulation.

beforeSend- is called before sending the ajax request. Useful for changing the 'nextHref' or append some parameter to 'nextHref'
afterContentLoad- is called after data is received, but  data is not appended to the scrolling div. Useful for data manipulation or formatting the received data.
reTriggerUntil - it will restart the scrolling when next button is clicked on 

getdata  and getOptions  public let you access the  jscroll data and option.

Removed animate and load function for better data handing and animation
$e.animate({scrollTop: $inner.outerHeight()}, 0, function() {})
animate don't let us to run our custom animation code. Better approach is to use it in 'Callback' function

  $inner.find('div.jscroll-added').last().load(data.nextHref, function(r, status) {});
.load is replaced with 
$.get(data.nextHref, function(r, status) {});

for better content handing 

Thanks
Kishore
Kishoreweblabs.com




