### PR TITLE
Wrong calculation for load-item-observer

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -123,8 +123,10 @@
                 }
                 if (_options.autoTrigger && (_options.autoTriggerUntil === false || _options.autoTriggerUntil > 0)) {
                     _nextWrap($next);
-                    var scrollingHeight = _$body.height() - $e.offset().top;
-                    if (scrollingHeight <= _$window.height()) {
+                     var scrollingBodyHeight = _$body.height() - $e.offset().top,
+                    	scrollingHeight = ($e.height() < scrollingBodyHeight) ? $e.height() : scrollingBodyHeight,
+                    	windowHeight = ($e.offset().top - _$window.scrollTop() > 0) ? _$window.height() - ($e.offset().top - $(window).scrollTop()) : _$window.height();
+                    if (scrollingHeight <= windowHeight) {
                         _observe();
                     }
                     _$scroll.unbind('.jscroll').bind('scroll.jscroll', function() {

--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -116,10 +116,6 @@
                 }
             },
             
-            _documentOffsetTop = function(e) {
-                return e.offsetTop + ( e.offsetParent ? _documentOffsetTop(e.offsetParent) : 0 );
-            },
-
             _setBindings = function() {
                 var $next = $e.find(_options.nextSelector).first();
                 if (!$next.length) {
@@ -127,7 +123,7 @@
                 }
                 if (_options.autoTrigger && (_options.autoTriggerUntil === false || _options.autoTriggerUntil > 0)) {
                     _nextWrap($next);
-                    var scrollingHeight = _$body.height() - _documentOffsetTop($e[0]);
+                    var scrollingHeight = _$body.height() - $e.offset().top;
                     if (scrollingHeight <= _$window.height()) {
                         _observe();
                     }

--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -115,6 +115,10 @@
                     return true;
                 }
             },
+            
+            _documentOffsetTop = function(e) {
+                return e.offsetTop + ( e.offsetParent ? _documentOffsetTop(e.offsetParent) : 0 );
+            },
 
             _setBindings = function() {
                 var $next = $e.find(_options.nextSelector).first();
@@ -123,7 +127,8 @@
                 }
                 if (_options.autoTrigger && (_options.autoTriggerUntil === false || _options.autoTriggerUntil > 0)) {
                     _nextWrap($next);
-                    if (_$body.height() <= _$window.height()) {
+                    var scrollingHeight = _$body.height() - _documentOffsetTop($e[0]);
+                    if (scrollingHeight <= _$window.height()) {
                         _observe();
                     }
                     _$scroll.unbind('.jscroll').bind('scroll.jscroll', function() {


### PR DESCRIPTION
Don't calculate the pixels between top document and jscroll element. 