### PR TITLE
Remove specify jquery version from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "url": "https://github.com/pklauzinski/jscroll/issues"
   },
   "homepage": "http://jscroll.com",
-  "dependencies": {
-    "jquery": "^1.7.4"
-  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.3",


### PR DESCRIPTION
Guess it'll be better to not add jQuery to dependencies. It's not working well if you already have another version of jQuery in your project.