### PR TITLE
Add support for callbacks on error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ $('.jscroll').jscroll({
 * `contentSelector ('')` - A convenience selector for loading only part of the content in the response for the next set of content. This selector will be ignored if left blank and will apply the entire response to the DOM.
 * `pagingSelector ('')` - Optionally define a selector for your paging controls so that they will be hidden, instead of just hiding the next page link.
 * `callback (false)` - Optionally define a callback function to be called after a set of content has been loaded.
+* `errorCallback (false)` - Optionally define a callback function to be called after an AJAX failure occurs.  This can be useful to clear the loading HTML.
 
 For more information on the `contentSelector` option and how it loads a response fragment, see the [jQuery documentation for the .load() method](https://api.jquery.com/load/).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,3 +71,10 @@ Optionally define a selector for your paging controls so that they will be hidde
 - Default: `false`
 
 Optionally define a callback function to be called after a set of content has been loaded.
+
+## errorCallback
+
+- Type: `Function|Boolean`
+- Default: `false`
+
+Optionally define a callback function to be called after an AJAX failure occurs.  This can be useful to clear the loading HTML.

--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -25,7 +25,8 @@
             nextSelector: 'a:last',
             contentSelector: '',
             pagingSelector: '',
-            callback: false
+            callback: false,
+            errorCallback: false
         }
     };
 
@@ -162,6 +163,9 @@
                     var nextHref = data.nextHref;
                     $inner.find('div.jscroll-added').last().load(nextHref, function(r, status) {
                         if (status === 'error') {
+                            if (_options.errorCallback) {
+                                _options.errorCallback();
+                            }
                             return _destroy();
                         }
                         var $next = $(this).find(_options.nextSelector).first();


### PR DESCRIPTION
Fixes #38 

Optionally define a callback function to be called after an AJAX failure occurs.  This can be useful to clear the loading HTML.
